### PR TITLE
Replace `module` name to `github.com/shirokovnv/web-observer`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go/webobs
+module github.com/shirokovnv/web-observer
 
 go 1.19
 


### PR DESCRIPTION
Usually `module` has names like:

- `github.com/go-co-op/gocron` for https://github.com/go-co-op/gocron
- `github.com/spf13/cobra` for https://github.com/spf13/cobra